### PR TITLE
Add static site alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
 # hostinger
+
+## Viewing the static version
+
+This project also includes a minimal static build that mirrors the React layout.
+
+1. Open `public/static/index.html` directly in your browser to view it.
+2. Optionally, run a local server from the project root:
+
+   ```bash
+   npm run static
+   ```
+
+   Then navigate to the printed URL to preview the static site.
+

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "node tools/generate-llms.js || true && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "static": "npx serve public/static"
   },
   "dependencies": {
     "@radix-ui/react-alert-dialog": "^1.0.5",

--- a/public/static/index.html
+++ b/public/static/index.html
@@ -1,0 +1,146 @@
+<!DOCTYPE html>
+<html lang="zh">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>绿能科技 - 静态版</title>
+  <!-- Tailwind CSS CDN -->
+  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@3.3.3/dist/tailwind.min.css" rel="stylesheet">
+  <!-- jQuery for small interactions -->
+  <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+  <!-- anime.js for subtle animations -->
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/animejs/3.2.1/anime.min.js"></script>
+  <!-- Leaflet for the map section -->
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+</head>
+<body class="bg-slate-950 text-gray-300 scroll-smooth">
+  <!-- Header -->
+  <header id="header" class="fixed top-0 left-0 right-0 z-50 bg-slate-900/50 backdrop-blur">
+    <nav class="container mx-auto px-6 py-4 flex items-center justify-between">
+      <div class="flex items-center space-x-2">
+        <span class="text-xl font-bold bg-gradient-to-r from-blue-400 to-green-400 bg-clip-text text-transparent">绿能科技</span>
+      </div>
+      <div class="hidden md:flex items-center space-x-8 text-sm font-medium">
+        <a href="#hero" class="hover:text-white">首页</a>
+        <a href="#products" class="hover:text-white">产品</a>
+        <a href="#about" class="hover:text-white">关于我们</a>
+        <a href="#location" class="hover:text-white">位置</a>
+        <a href="#contact" class="hover:text-white">联系我们</a>
+      </div>
+    </nav>
+  </header>
+
+  <main class="pt-20 space-y-24">
+    <!-- Hero -->
+    <section id="hero" class="min-h-screen flex items-center justify-center relative overflow-hidden">
+      <div class="absolute inset-0 hero-gradient"></div>
+      <div class="container mx-auto px-6 text-center relative z-10">
+        <h1 class="text-5xl md:text-7xl font-bold mb-6 bg-gradient-to-r from-blue-400 via-green-400 to-blue-600 bg-clip-text text-transparent">绿能科技</h1>
+        <p class="text-xl md:text-2xl mb-8 leading-relaxed">专业储能电池解决方案提供商<br><span class="text-lg text-blue-400">高效 · 安全 · 可靠 · 环保</span></p>
+        <div class="flex flex-wrap justify-center gap-8 mb-12">
+          <div class="flex items-center space-x-2 glass-effect px-4 py-2 rounded-full"><span class="text-yellow-400">⚡</span><span>高效储能</span></div>
+          <div class="flex items-center space-x-2 glass-effect px-4 py-2 rounded-full"><span class="text-blue-400">🛡️</span><span>安全可靠</span></div>
+          <div class="flex items-center space-x-2 glass-effect px-4 py-2 rounded-full"><span class="text-green-400">🌿</span><span>绿色环保</span></div>
+        </div>
+        <button id="toProducts" class="bg-gradient-to-r from-blue-600 to-green-600 text-white px-8 py-3 rounded-full text-lg font-semibold">探索我们的产品</button>
+      </div>
+      <div class="absolute bottom-8 left-1/2 transform -translate-x-1/2 cursor-pointer" id="scrollDown">
+        <svg class="h-8 w-8 text-blue-400" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7"></path></svg>
+      </div>
+    </section>
+
+    <!-- Products -->
+    <section id="products" class="py-20">
+      <div class="container mx-auto px-6">
+        <h2 class="text-4xl md:text-5xl font-bold mb-6 text-center bg-gradient-to-r from-blue-400 to-green-400 bg-clip-text text-transparent">我们的产品</h2>
+        <p class="text-xl text-center mb-12">从家用到工业级，我们提供全方位的储能电池解决方案</p>
+        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+          <!-- product 1 -->
+          <div class="product-card rounded-2xl p-8 bg-slate-900/50 hover:shadow-2xl transition">
+            <div class="mb-6">
+              <div class="w-16 h-16 rounded-full bg-gradient-to-r from-blue-500 to-cyan-500 flex items-center justify-center mb-4"><span class="text-white">🔋</span></div>
+              <img class="w-full h-48 object-cover rounded-lg mb-4" src="https://images.unsplash.com/photo-1680591483838-67a3fe473b93" alt="家用储能电池系统">
+            </div>
+            <h3 class="text-2xl font-bold text-white mb-2">家用储能电池系统</h3>
+            <p class="text-blue-400 text-lg font-semibold mb-4">10kWh - 20kWh</p>
+            <ul class="space-y-2 mb-6 text-sm">
+              <li>• 智能管理</li>
+              <li>• 安全保护</li>
+              <li>• 长寿命</li>
+            </ul>
+            <button class="learn-more w-full bg-gradient-to-r from-blue-500 to-cyan-500 text-white py-2 rounded-lg">了解更多</button>
+          </div>
+          <!-- product 2 -->
+          <div class="product-card rounded-2xl p-8 bg-slate-900/50 hover:shadow-2xl transition">
+            <div class="mb-6">
+              <div class="w-16 h-16 rounded-full bg-gradient-to-r from-green-500 to-emerald-500 flex items-center justify-center mb-4"><span class="text-white">⚡</span></div>
+              <img class="w-full h-48 object-cover rounded-lg mb-4" src="https://images.unsplash.com/photo-1680591483838-67a3fe473b93" alt="商用储能解决方案">
+            </div>
+            <h3 class="text-2xl font-bold text-white mb-2">商用储能解决方案</h3>
+            <p class="text-green-400 text-lg font-semibold mb-4">50kWh - 500kWh</p>
+            <ul class="space-y-2 mb-6 text-sm">
+              <li>• 模块化设计</li>
+              <li>• 远程监控</li>
+              <li>• 快速响应</li>
+            </ul>
+            <button class="learn-more w-full bg-gradient-to-r from-green-500 to-emerald-500 text-white py-2 rounded-lg">了解更多</button>
+          </div>
+          <!-- product 3 -->
+          <div class="product-card rounded-2xl p-8 bg-slate-900/50 hover:shadow-2xl transition">
+            <div class="mb-6">
+              <div class="w-16 h-16 rounded-full bg-gradient-to-r from-purple-500 to-pink-500 flex items-center justify-center mb-4"><span class="text-white">🛡️</span></div>
+              <img class="w-full h-48 object-cover rounded-lg mb-4" src="https://images.unsplash.com/photo-1680591483838-67a3fe473b93" alt="工业级储能系统">
+            </div>
+            <h3 class="text-2xl font-bold text-white mb-2">工业级储能系统</h3>
+            <p class="text-purple-400 text-lg font-semibold mb-4">1MWh - 10MWh</p>
+            <ul class="space-y-2 mb-6 text-sm">
+              <li>• 高功率密度</li>
+              <li>• 智能调度</li>
+              <li>• 并网友好</li>
+            </ul>
+            <button class="learn-more w-full bg-gradient-to-r from-purple-500 to-pink-500 text-white py-2 rounded-lg">了解更多</button>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- About -->
+    <section id="about" class="py-20">
+      <div class="container mx-auto px-6">
+        <h2 class="text-4xl md:text-5xl font-bold mb-6 text-center bg-gradient-to-r from-blue-400 to-green-400 bg-clip-text text-transparent">关于我们</h2>
+        <p class="text-xl text-center mb-12">绿能科技成立于2014年，专注于储能电池技术的研发、生产和销售，是行业领先的储能解决方案提供商</p>
+      </div>
+    </section>
+
+    <!-- Location -->
+    <section id="location" class="py-20">
+      <div class="container mx-auto px-6 text-center">
+        <h2 class="text-4xl md:text-5xl font-bold mb-6 bg-gradient-to-r from-blue-400 to-green-400 bg-clip-text text-transparent">我们的位置</h2>
+        <p class="text-xl mb-6">深圳市南山区科技园</p>
+        <div id="map" class="mx-auto" style="height:300px"></div>
+      </div>
+    </section>
+
+    <!-- Contact -->
+    <section id="contact" class="py-20">
+      <div class="container mx-auto px-6">
+        <h2 class="text-4xl md:text-5xl font-bold mb-6 text-center bg-gradient-to-r from-blue-400 to-green-400 bg-clip-text text-transparent">联系我们</h2>
+        <form id="contactForm" class="max-w-xl mx-auto space-y-4">
+          <input type="text" name="name" placeholder="姓名*" required class="w-full px-4 py-2 bg-gray-800/50 border border-gray-600 rounded">
+          <input type="email" name="email" placeholder="邮箱*" required class="w-full px-4 py-2 bg-gray-800/50 border border-gray-600 rounded">
+          <textarea name="message" placeholder="留言内容*" required rows="4" class="w-full px-4 py-2 bg-gray-800/50 border border-gray-600 rounded"></textarea>
+          <button type="submit" class="w-full bg-gradient-to-r from-blue-600 to-green-600 text-white py-2 rounded">发送询盘</button>
+        </form>
+      </div>
+    </section>
+  </main>
+
+  <!-- Footer -->
+  <footer class="bg-gradient-to-b from-slate-900 to-black py-16 text-sm text-gray-400 text-center">
+    © <span id="year"></span> 绿能科技有限公司. 保留所有权利.
+  </footer>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/public/static/script.js
+++ b/public/static/script.js
@@ -1,0 +1,57 @@
+$(function () {
+  $('#year').text(new Date().getFullYear());
+
+  function smoothScroll(target) {
+    $('html, body').animate({ scrollTop: $(target).offset().top }, 600);
+  }
+
+  $('#toProducts, #scrollDown').on('click', function () {
+    smoothScroll('#products');
+  });
+
+  $('header a').on('click', function (e) {
+    e.preventDefault();
+    smoothScroll($(this).attr('href'));
+  });
+
+  function showToast(message) {
+    const toast = $('<div class="fixed bottom-4 right-4 bg-gray-800 text-white px-4 py-2 rounded shadow pointer-events-none opacity-0"></div>').text(message).appendTo('body');
+    anime({
+      targets: toast[0],
+      opacity: [0, 1],
+      translateY: [20, 0],
+      duration: 300,
+      easing: 'easeOutQuad',
+      complete: function () {
+        setTimeout(() => {
+          anime({
+            targets: toast[0],
+            opacity: [1, 0],
+            translateY: [0, 20],
+            duration: 300,
+            easing: 'easeInQuad',
+            complete: () => toast.remove()
+          });
+        }, 2000);
+      }
+    });
+  }
+
+  $('.learn-more').on('click', function () {
+    showToast('🚧 此功能尚未实现');
+  });
+
+  $('#contactForm').on('submit', function (e) {
+    e.preventDefault();
+    showToast('询盘已提交，我们会尽快联系您。');
+    this.reset();
+  });
+
+  if ($('#map').length && window.L) {
+    const map = L.map('map').setView([22.5431, 114.0579], 13);
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+      attribution: '© OpenStreetMap'
+    }).addTo(map);
+    L.marker([22.5431, 114.0579]).addTo(map);
+  }
+});


### PR DESCRIPTION
## Summary
- add `public/static` with an HTML mirror of the React layout and a small JS file
- include CDN links for Tailwind, jQuery, anime.js and Leaflet
- implement simple smooth scrolling and toast notifications
- document usage in the README
- expose an optional `npm run static` script to preview the static site

## Testing
- `npm run static` *(fails: requires interactive installation)*

------
https://chatgpt.com/codex/tasks/task_e_6877572a853083249c0e29473fb527d3